### PR TITLE
スコア計算方法の変更

### DIFF
--- a/score.py
+++ b/score.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-score_num_log = [0, 10, 20, 30, 40]
+score_num_log = [0, 10, 20, 30, 40, 50]
 threshold_num_log = [0, 3, 6, 9, 12]
 keys = ['動詞', '名詞', '形容詞', '副詞', '助動詞']
 
@@ -17,19 +17,13 @@ class Score:
 
 	# TODO: example
 	def score_log(self, num, members):
-		score = 0
+		count = 0
 
-		if num == threshold_num_log[0]:
-			score = score_num_log[0]
-		elif threshold_num_log[0] < num and num <= threshold_num_log[1]:
-			score = score_num_log[1]
-		elif threshold_num_log[1] < num and num <= threshold_num_log[2]:
-			score = score_num_log[2]
-		elif threshold_num_log[2] < num and num <= threshold_num_log[3]:
-			score = score_num_log[3]
-		elif threshold_num_log[3] < num and num <= threshold_num_log[4]:
-			score = score_num_log[4]
-		return score / members
+		for threshold in threshold_num_log:
+			if num <= threshold:
+				return score_num_log[count]
+			count += 1
+		return score_num_log[count]
 
 	# lines: リスト（[0] = 単語, [1] = 品詞）　
 	def calculate_pn_score(self, lines):

--- a/slackLog.py
+++ b/slackLog.py
@@ -6,13 +6,14 @@ from slack import Slack
 from score import Score
 
 # oledest_day日前から
-oldest_day=-1
+oldest_day=-7
 
 now = datetime.now()
 duration_day=1
 oldest = datetime(now.year, now.month, now.day, 0, 0, 0, 0) + timedelta(days=oldest_day)
 latest = oldest + timedelta(days=duration_day)
 score_all = 0
+score_pn_all = 0
 
 print(oldest, ' ~ ', latest)
 
@@ -41,8 +42,10 @@ for id in ids:
 		line = p.parse_wordpart(message)
 		score_pn += sc.calculate_pn_score(line)
 	score_pn = score_pn / len(log.logs)
+	score_pn_all += score_pn
 	print("np-score:", score_pn)
 	print(p.get_params())
 	print("\n")
 
 print('Score: ', score_all)
+print('Score: ', score_pn_all / len(ids))


### PR DESCRIPTION
# 変更点
## 1つだけ
### 計算方法の変更

闇を感じていたので。。
`threshold_num_log`はログの点数をつける閾値で、`score_num_log`はそれに対する点数。0個、3個、6個、9個、12個のログがあったら、それぞれ0点、10点、20点…のようにつけるという感じである。この数字をリストでいじれるようにしてあるって感じです。この辺りの数値は後からいじりませう。
## 備考

`slackLog.py`のoldest_dayを-7にしてあるのは、一番ログの多いちょうど一週間前でテストしたからです。-1とかにすれば昨日のログがとれます。（ただしログはない）
